### PR TITLE
Fix incorrect repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     },
     "publisher": "charliermarsh",
     "license": "MIT",
-    "homepage": "https://github.com/charliermarsh/ruff-vscode",
+    "homepage": "https://github.com/charliermarsh/vscode-ruff",
     "repository": {
         "type": "git",
-        "url": "https://github.com/charliermarsh/ruff-vscode.git"
+        "url": "https://github.com/charliermarsh/vscode-ruff.git"
     },
     "bugs": {
-        "url": "https://github.com/charliermarsh/ruff-vscode/issues"
+        "url": "https://github.com/charliermarsh/vscode-ruff/issues"
     },
     "icon": "icon.png",
     "galleryBanner": {


### PR DESCRIPTION
Fix https://github.com/charliermarsh/ruff-vscode to https://github.com/charliermarsh/vscode-ruff.