### PR TITLE
add changelog.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+See [here](https://github.com/charliermarsh/ruff/releases) for the Ruff release notes
+
+## 2022.0.14 (15 November 2022)
+
+What's Changed
+
+- Update README.md by @akanz1 in [#21](https://github.com/charliermarsh/vscode-ruff/pull/21)
+- Bump Ruff version to 0.0.121 by @charliermarsh in [#22](https://github.com/charliermarsh/vscode-ruff/pull/22)
+- Bump version to 2022.0.14 by @charliermarsh in [#23](https://github.com/charliermarsh/vscode-ruff/pull/23)
+
+## 2022.0.13 (13 November 2022)
+
+What's Changed
+
+- Use scripts path when interpreter is set by @charliermarsh in [#18](https://github.com/charliermarsh/vscode-ruff/pull/18)
+- Bump Ruff version to 0.0.117 by @charliermarsh in [#19](https://github.com/charliermarsh/vscode-ruff/pull/19)
+
+## 2022.0.12 (11 November 2022)
+
+What's Changed
+
+- Add .idea and .ruff_cache to .vscodeignore by @charliermarsh in [#14](https://github.com/charliermarsh/vscode-ruff/pull/14)


### PR DESCRIPTION
When getting an extension update it's nice to take a quick look at new features and changes that come with it.

This PR adds a CHANGELOG.md which should be picked up by the vscode extension to display a changelog tab.

I've added the most recent releases and ideally, this would also include all changes from ruff between the different versions of the vscode extension. 

However, lowest maintenance effort is probably to simply copy the auto-generated vscode-ruff release notes into the CHANGELOG.md or to just point a link to the github release notes (see example below), which is not nice but at least users can access the release notes with a click.

![image](https://user-images.githubusercontent.com/51492342/202238139-057da7c1-6c14-40df-bcf0-f320bd724aed.png)
