### PR TITLE
Fix 'Exception ignored in atexit callback' in jsonrpc

### DIFF
--- a/bundled/tool/jsonrpc.py
+++ b/bundled/tool/jsonrpc.py
@@ -132,8 +132,8 @@ class ProcessManager:
         self._rpc: dict[str, JsonRpc] = {}
         self._lock = threading.Lock()
         self._thread_pool = ThreadPoolExecutor(10)
+        atexit.register(self.stop_all_processes)
 
-    @atexit.register  # type: ignore
     def stop_all_processes(self):
         """Send exit command to all processes and shutdown transport."""
         for i in self._rpc.values():


### PR DESCRIPTION
This cleans up Ruff's "Output" tab in VSCode and fixes #53